### PR TITLE
feat: Add Discord notification workflow for PRs

### DIFF
--- a/.github/workflows/discord-notif.yml
+++ b/.github/workflows/discord-notif.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send embed notification to Discord
-        uses: Ilshidur/action-discord@v2
+        uses: Ilshidur/action-discord@master
         with:
           args: |
             {

--- a/.github/workflows/discord-notif.yml
+++ b/.github/workflows/discord-notif.yml
@@ -1,0 +1,47 @@
+name: PR Notifications
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send embed notification to Discord
+        uses: Ilshidur/action-discord@v2
+        with:
+          args: |
+            {
+              "embeds": [
+                {
+                  "title": "📢 New Pull Request Ready for Review!",
+                  "url": "${{ github.event.pull_request.html_url }}",
+                  "color": 5814783,
+                  "author": {
+                    "name": "${{ github.event.pull_request.user.login }}",
+                    "url": "${{ github.event.pull_request.user.html_url }}",
+                    "icon_url": "${{ github.event.pull_request.user.avatar_url }}"
+                  },
+                  "fields": [
+                    {
+                      "name": "Title",
+                      "value": "${{ github.event.pull_request.title }}"
+                    },
+                    {
+                      "name": "Branch",
+                      "value": "${{ github.event.pull_request.head.ref }}",
+                      "inline": true
+                    },
+                    {
+                      "name": "Base",
+                      "value": "${{ github.event.pull_request.base.ref }}",
+                      "inline": true
+                    }
+                  ],
+                  "timestamp": "${{ github.event.pull_request.created_at }}"
+                }
+              ]
+            }
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/discord-notif.yml
+++ b/.github/workflows/discord-notif.yml
@@ -12,35 +12,12 @@ jobs:
         uses: Ilshidur/action-discord@master
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          DISCORD_USERNAME: "GitHub Actions"
         with:
-          args: >
-            {"embeds":[
-              {
-                "title":"📢 New Pull Request Ready for Review!",
-                "url":"${{ github.event.pull_request.html_url }}",
-                "color":5814783,
-                "author":{
-                  "name":"${{ github.event.pull_request.user.login }}",
-                  "url":"${{ github.event.pull_request.user.html_url }}",
-                  "icon_url":"${{ github.event.pull_request.user.avatar_url }}"
-                },
-                "fields":[
-                  {
-                    "name":"Title",
-                    "value":"${{ github.event.pull_request.title }}"
-                  },
-                  {
-                    "name":"Branch",
-                    "value":"${{ github.event.pull_request.head.ref }}",
-                    "inline":true
-                  },
-                  {
-                    "name":"Base",
-                    "value":"${{ github.event.pull_request.base.ref }}",
-                    "inline":true
-                  }
-                ],
-                "timestamp":"${{ github.event.pull_request.created_at }}"
-              }
-            ]}
+          args: |
+            📢 **New Pull Request Ready for Review!**
+            • **Title:** ${{ github.event.pull_request.title }}
+            • **Author:** ${{ github.event.pull_request.user.login }}
+            • **Branch:** `${{ github.event.pull_request.head.ref }}`
+            • **Base:** `${{ github.event.pull_request.base.ref }}`
+
+            🔗 ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/discord-notif.yml
+++ b/.github/workflows/discord-notif.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           args: |
             📢 **New Pull Request Ready for Review!**
+            • **Repository:** ${{ github.repository }}
             • **Title:** ${{ github.event.pull_request.title }}
             • **Author:** ${{ github.event.pull_request.user.login }}
             • **Branch:** `${{ github.event.pull_request.head.ref }}`

--- a/.github/workflows/discord-notif.yml
+++ b/.github/workflows/discord-notif.yml
@@ -10,38 +10,37 @@ jobs:
     steps:
       - name: Send embed notification to Discord
         uses: Ilshidur/action-discord@master
-        with:
-          args: |
-            {
-              "embeds": [
-                {
-                  "title": "📢 New Pull Request Ready for Review!",
-                  "url": "${{ github.event.pull_request.html_url }}",
-                  "color": 5814783,
-                  "author": {
-                    "name": "${{ github.event.pull_request.user.login }}",
-                    "url": "${{ github.event.pull_request.user.html_url }}",
-                    "icon_url": "${{ github.event.pull_request.user.avatar_url }}"
-                  },
-                  "fields": [
-                    {
-                      "name": "Title",
-                      "value": "${{ github.event.pull_request.title }}"
-                    },
-                    {
-                      "name": "Branch",
-                      "value": "${{ github.event.pull_request.head.ref }}",
-                      "inline": true
-                    },
-                    {
-                      "name": "Base",
-                      "value": "${{ github.event.pull_request.base.ref }}",
-                      "inline": true
-                    }
-                  ],
-                  "timestamp": "${{ github.event.pull_request.created_at }}"
-                }
-              ]
-            }
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: "GitHub Actions"
+        with:
+          args: >
+            {"embeds":[
+              {
+                "title":"📢 New Pull Request Ready for Review!",
+                "url":"${{ github.event.pull_request.html_url }}",
+                "color":5814783,
+                "author":{
+                  "name":"${{ github.event.pull_request.user.login }}",
+                  "url":"${{ github.event.pull_request.user.html_url }}",
+                  "icon_url":"${{ github.event.pull_request.user.avatar_url }}"
+                },
+                "fields":[
+                  {
+                    "name":"Title",
+                    "value":"${{ github.event.pull_request.title }}"
+                  },
+                  {
+                    "name":"Branch",
+                    "value":"${{ github.event.pull_request.head.ref }}",
+                    "inline":true
+                  },
+                  {
+                    "name":"Base",
+                    "value":"${{ github.event.pull_request.base.ref }}",
+                    "inline":true
+                  }
+                ],
+                "timestamp":"${{ github.event.pull_request.created_at }}"
+              }
+            ]}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate notifications for pull requests in Discord. The workflow sends an embed message to a Discord channel whenever a pull request is opened or marked as ready for review.

**Automation and Integration:**

* Added `.github/workflows/discord-notif.yml` to send Discord notifications for newly opened or ready-for-review pull requests using the `Ilshidur/action-discord` GitHub Action. The notification includes pull request details such as title, author, branch, base, and a direct link.