### PR TITLE
Add unidecode to convert regional letters to standard english letters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "requests>=2.32.5",
+    "unidecode>=1.4.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/text_fetching/fetcher.py
+++ b/src/text_fetching/fetcher.py
@@ -1,5 +1,6 @@
 import requests
 import random
+from unidecode import unidecode
 
 GUTENDEX_BASE_URL = "https://gutendex.com/books"
 
@@ -106,4 +107,4 @@ class Fetcher:
             raise ValueError(
                 "Argument must be a string"
             )
-        return "".join([c.lower() for c in text if c.isalpha()])
+        return unidecode("".join([c.lower() for c in text if c.isalpha()]))

--- a/test/text-fetching/test_fetcher.py
+++ b/test/text-fetching/test_fetcher.py
@@ -25,6 +25,9 @@ def short_text():
 def no_text():
     return None
 
+@pytest.fixture
+def accented_text():
+    return "kožušček François æåø äö"
 
 def test_format_text(sample_text_book):
     fetcher = Fetcher()
@@ -43,6 +46,12 @@ def test_format_notext(no_text):
     with pytest.raises(ValueError) as excinfo:
         fetcher.format_text(no_text)
     assert "Argument must be a string" in str(excinfo.value)
+
+
+def test_format_regional_text(accented_text):
+    fetcher = Fetcher()
+    formatted_text = fetcher.format_text(accented_text)
+    assert(formatted_text == "kozuscekfrancoisaeaoao")
 
 
 def test_slicing_text(long_text):

--- a/test/text-fetching/test_fetcher.py
+++ b/test/text-fetching/test_fetcher.py
@@ -27,7 +27,7 @@ def no_text():
 
 @pytest.fixture
 def accented_text():
-    return "kožušček François æåø äö"
+    return "kožušček François æåø äö êèéêñ"
 
 def test_format_text(sample_text_book):
     fetcher = Fetcher()
@@ -51,7 +51,7 @@ def test_format_notext(no_text):
 def test_format_regional_text(accented_text):
     fetcher = Fetcher()
     formatted_text = fetcher.format_text(accented_text)
-    assert(formatted_text == "kozuscekfrancoisaeaoao")
+    assert(formatted_text == "kozuscekfrancoisaeaoaoeeeen")
 
 
 def test_slicing_text(long_text):

--- a/uv.lock
+++ b/uv.lock
@@ -59,6 +59,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },
+    { name = "unidecode" },
 ]
 
 [package.dev-dependencies]
@@ -70,7 +71,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32.5" }]
+requires-dist = [
+    { name = "requests", specifier = ">=2.32.5" },
+    { name = "unidecode", specifier = ">=1.4.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -289,6 +293,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/54/6177a0dc10bce6f43e392a2192e6018755473283d0cf43cc7e6afc182aea/ruff-0.13.1-py3-none-win32.whl", hash = "sha256:55e9efa692d7cb18580279f1fbb525146adc401f40735edf0aaeabd93099f9a0", size = 12178448, upload-time = "2025-09-18T19:52:35.545Z" },
     { url = "https://files.pythonhosted.org/packages/64/51/c6a3a33d9938007b8bdc8ca852ecc8d810a407fb513ab08e34af12dc7c24/ruff-0.13.1-py3-none-win_amd64.whl", hash = "sha256:3a3fb595287ee556de947183489f636b9f76a72f0fa9c028bdcabf5bab2cc5e5", size = 13286458, upload-time = "2025-09-18T19:52:38.198Z" },
     { url = "https://files.pythonhosted.org/packages/fd/04/afc078a12cf68592345b1e2d6ecdff837d286bac023d7a22c54c7a698c5b/ruff-0.13.1-py3-none-win_arm64.whl", hash = "sha256:c0bae9ffd92d54e03c2bf266f466da0a65e145f298ee5b5846ed435f6a00518a", size = 12437893, upload-time = "2025-09-18T19:52:41.283Z" },
+]
+
+[[package]]
+name = "unidecode"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/7d/a8a765761bbc0c836e397a2e48d498305a865b70a8600fd7a942e85dcf63/Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23", size = 200149, upload-time = "2025-04-24T08:45:03.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/b7/559f59d57d18b44c6d1250d2eeaa676e028b9c527431f5d0736478a73ba1/Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021", size = 235837, upload-time = "2025-04-24T08:45:01.609Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request enhances the text formatting functionality by ensuring that accented and non-ASCII characters are normalized to their closest ASCII equivalents. It does so by introducing the `unidecode` library as a dependency and updating both the code and tests to handle accented text appropriately.

**Dependency and text normalization improvements:**

* Added `unidecode` as a dependency in `pyproject.toml` to support transliteration of non-ASCII characters.
* Updated `src/text_fetching/fetcher.py` to import `unidecode` and apply it in the `format_text` method, ensuring all output is ASCII-only and lowercased. [[1]](diffhunk://#diff-5a05d3bbb81cf5e7980a07bf7461da70813f41e76847caf6e66975496f0010f8R3) [[2]](diffhunk://#diff-5a05d3bbb81cf5e7980a07bf7461da70813f41e76847caf6e66975496f0010f8L109-R110)

**Testing enhancements:**

* Added a new pytest fixture `accented_text` and a corresponding test `test_format_regional_text` to verify that accented and special characters are correctly normalized in the formatted output. [[1]](diffhunk://#diff-c0469c5748e9772e6e098a1b279aceb9b03b066fb8f42cf9a818416fdc1bb607R28-R30) [[2]](diffhunk://#diff-c0469c5748e9772e6e098a1b279aceb9b03b066fb8f42cf9a818416fdc1bb607R51-R56)