### PR TITLE
Cipher length fix

### DIFF
--- a/src/text_fetching/fetcher.py
+++ b/src/text_fetching/fetcher.py
@@ -86,6 +86,8 @@ class Fetcher:
             raise ValueError(
                 "Length of book_text must be equal to or greater than min_len"
             )
+        
+        book_text = self.format_text(book_text)
 
         # Get random slice
         start_idx = random.randint(0, max(0, len(book_text) - min_len))

--- a/test/text-fetching/test_fetcher.py
+++ b/test/text-fetching/test_fetcher.py
@@ -57,11 +57,10 @@ def test_format_regional_text(accented_text):
 def test_slicing_text(long_text):
     fetcher = Fetcher()
     sliced_text = fetcher.get_random_book_slice(
-        book_text=long_text, min_len=100, max_len=5000
+        book_text=long_text, min_len=100, max_len=100
     )
     assert isinstance(sliced_text, str)
-    assert len(sliced_text) <= 5000
-    assert len(sliced_text) >= 100
+    assert len(sliced_text) == 100
 
 
 def test_slicing_no_text(no_text):


### PR DESCRIPTION
This pull request introduces a minor functional improvement and a corresponding test update related to how book text is sliced in the `Fetcher` class. The main change ensures that book text is formatted before slicing, and the test is updated to check for an exact slice length.

Improvements to text processing:

* Ensured that `book_text` is formatted using `self.format_text` before performing the random slice in `Fetcher.get_random_book_slice`, which helps maintain consistency and correctness in the sliced output.

Test updates:

* Updated the `test_slicing_text` test to use a fixed `max_len` of 100 and assert that the length of the sliced text is exactly 100, reflecting the new deterministic behavior.