### PR TITLE
Ensure all homophones are used (if possible)

### DIFF
--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -1,6 +1,7 @@
-from .homophones import extract_homophones
+from .homophones import extract_homophones, get_homophones
 from .frequency import frequencies
 import random
+from collections import Counter
 
 
 class Cipher:
@@ -58,10 +59,18 @@ class Cipher:
         Returns:
                 str: The resulting ciphertext as a string of numbers separated by spaces.
         """
+        counts = Counter(ch for ch in self.plaintext if ch in self.key)
+
+        homophones: dict[str, list[int]] = {}
+        ptr: dict[str, int] = {}
+        for letter, count in counts.items():
+            homophones[letter] = get_homophones(self.key[letter], count)
+            ptr[letter] = 0
+
         ciphertext_numbers: list[str] = []
         for char in self.plaintext:
-            homophones = self.key[char]
-            ciphertext_numbers.append(str(random.choice(homophones)))
+            ciphertext_numbers.append(str(homophones[char][ptr[char]]))
+            ptr[char] += 1
         return " ".join(ciphertext_numbers)
 
     def generate_difficulty(self) -> int:

--- a/src/encipherment/homophones.py
+++ b/src/encipherment/homophones.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+import random
 
 
 def extract_homophones(cipher_symbols, frequencies):
@@ -23,3 +24,24 @@ def extract_homophones(cipher_symbols, frequencies):
 	)
 
 	return homophones_dict
+
+def get_homophones(homophones: list[int], letter_occurrences: int) -> list[int]:
+	"""Get a list of homophones for a letter generated from the list of available homophones.
+	It ensures that all homophones are used at least once if letter_occurrences is greater than the number of available homophones.
+	Args:
+		homophones (list[int]): A list of available homophones.
+		letter_occurrences (int): The number of homophones to select for the letter.
+
+	Returns:
+		list[int]: A list of selected homophones.
+	"""
+	if letter_occurrences < len(homophones):
+		return random.sample(homophones, letter_occurrences) # Impossible to use all homophones, so just sample
+
+	selected_homophones = homophones.copy()
+ 
+	for _ in range(letter_occurrences - len(homophones)):
+		selected_homophones.append(random.choice(homophones))
+
+	random.shuffle(selected_homophones)
+	return selected_homophones

--- a/test/encipherment/test_cipher.py
+++ b/test/encipherment/test_cipher.py
@@ -31,6 +31,14 @@ def test_legal_plaintext(sample_text_legal):
     assert all(isinstance(v, list) for v in cipher.key.values())
     assert isinstance(cipher.ciphertext, str)
     assert all(num.isdigit() for num in cipher.ciphertext.split())
+    
+def test_all_homophones_used(sample_text_legal):
+	cipher = Cipher(sample_text_legal)
+	used_homophones = set(int(num) for num in cipher.ciphertext.split())
+	all_homophones = set()
+	for homophones in cipher.key.values():
+		all_homophones.update(homophones)
+	assert used_homophones == all_homophones, f"Used homophones {used_homophones} do not match all homophones {all_homophones}"
 
 
 def test_illegal_plaintext(sample_texts_illegal):

--- a/test/encipherment/test_homophones.py
+++ b/test/encipherment/test_homophones.py
@@ -1,3 +1,4 @@
+import random
 import pytest
 from decimal import Decimal
 
@@ -6,39 +7,39 @@ import encipherment.homophones
 
 @pytest.fixture
 def homophone_dict():
-    # Return a dictionary of letters to homophone counts that is near expected frequencies, startng with e, t, a...
-    return {
-        "e": 7,
-        "t": 9,
-        "a": 6,
-        "o": 5,
-        "i": 3,
-        "n": 3,
-        "s": 6,
-        "r": 3,
-        "h": 2,
-        "d": 5,
-        "l": 2,
-        "u": 1,
-        "c": 1,
-        "m": 4,
-        "f": 2,
-        "y": 1,
-        "w": 3,
-        "g": 1,
-        "p": 1,
-        "b": 1,
-        "v": 1,
-        "k": 1,
-        "x": 1,
-        "q": 1,
-        "j": 2,
-        "z": 1,
-    }
-    
+	# Return a dictionary of letters to homophone counts that is near expected frequencies, startng with e, t, a...
+	return {
+		"e": 7,
+		"t": 9,
+		"a": 6,
+		"o": 5,
+		"i": 3,
+		"n": 3,
+		"s": 6,
+		"r": 3,
+		"h": 2,
+		"d": 5,
+		"l": 2,
+		"u": 1,
+		"c": 1,
+		"m": 4,
+		"f": 2,
+		"y": 1,
+		"w": 3,
+		"g": 1,
+		"p": 1,
+		"b": 1,
+		"v": 1,
+		"k": 1,
+		"x": 1,
+		"q": 1,
+		"j": 2,
+		"z": 1,
+	}
+	
 @pytest.fixture
 def sample_frequencies():
-    return {
+	return {
 		"e": Decimal("12.03"),
 		"t": Decimal("9.10"),
 		"a": Decimal("8.12"),
@@ -69,19 +70,38 @@ def sample_frequencies():
 
 
 def test_extract_homophones(sample_frequencies):
-    cipher_symbols = [100, 55, 26, 250]  # Must be at least 26 to cover all letters
-    for cipher_symbol in cipher_symbols:
-        homophones_dict = encipherment.homophones.extract_homophones(cipher_symbol, sample_frequencies)
-        total_homophones = sum(homophones_dict.values())
-        assert all(
-            (count >= 1 if sample_frequencies[letter] > 0 else count == 0)
-            for letter, count in homophones_dict.items()
-        )
-        assert total_homophones <= cipher_symbol + 10  # Allow a small margin due to noise
+	cipher_symbols = [100, 55, 26, 250]  # Must be at least 26 to cover all letters
+	for cipher_symbol in cipher_symbols:
+		homophones_dict = encipherment.homophones.extract_homophones(cipher_symbol, sample_frequencies)
+		total_homophones = sum(homophones_dict.values())
+		assert all(
+			(count >= 1 if sample_frequencies[letter] > 0 else count == 0)
+			for letter, count in homophones_dict.items()
+		)
+		assert total_homophones <= cipher_symbol + 10  # Allow a small margin due to noise
 
 
 def test_extract_homophones_small_numbers(sample_frequencies):
-    invalid_cipher_symbols = [25, 4, 2, 1, 0]  # Must be at least 26 to cover all letters
-    for cipher_symbol in invalid_cipher_symbols:
-        encipherment.homophones.extract_homophones(cipher_symbol, sample_frequencies)
-        assert True  # Just ensure no exception is raised
+	invalid_cipher_symbols = [25, 4, 2, 1, 0]  # Must be at least 26 to cover all letters
+	for cipher_symbol in invalid_cipher_symbols:
+		encipherment.homophones.extract_homophones(cipher_symbol, sample_frequencies)
+		assert True  # Just ensure no exception is raised
+		
+		
+def test_get_homophones(homophone_dict):
+	for _, count in homophone_dict.items():
+		occurences = random.randint(count, count + 10)  # Ensure at least as many occurences as homophones
+		homophones = encipherment.homophones.get_homophones(list(range(1, count + 1)), occurences)
+		assert len(homophones) == occurences
+		assert all(h in range(1, count + 1) for h in homophones)
+		assert set(homophones) == set(range(1, count + 1))  # Ensure all homophones are used at least once
+  
+  
+def test_get_homophones_few_occurences(homophone_dict):
+	for _, count in homophone_dict.items():
+		if count > 1:
+			occurences = random.randint(1, count - 1)  # Ensure fewer occurences than homophones
+			homophones = encipherment.homophones.get_homophones(list(range(1, count + 1)), occurences)
+			assert len(homophones) == occurences
+			assert all(h in range(1, count + 1) for h in homophones)
+			assert len(set(homophones)) == occurences  # Ensure all homophones are unique


### PR DESCRIPTION
This pull request improves the handling and testing of homophone assignment in the encipherment process. The main changes ensure that all available homophones are used at least once when enciphering, especially when the number of letter occurrences exceeds the number of homophones. The update also adds comprehensive tests for this new logic.

### Homophone assignment improvements
* Added a new function `get_homophones` in `homophones.py` to generate a list of homophones for each letter, ensuring all homophones are used at least once if needed, and randomizing their order for each encipherment. (`src/encipherment/homophones.py`, [src/encipherment/homophones.pyR27-R47](diffhunk://#diff-88009526a85da0d7e1bdd364b9b8854087ea8ea2a6a84ddff97307c429140e4bR27-R47))
* Modified the `Cipher.encipher` method to use `get_homophones` so that homophones are assigned deterministically and exhaustively per letter occurrence, instead of randomly choosing with replacement. (`src/encipherment/cipher.py`, [[1]](diffhunk://#diff-e644090a9fdd02d5d3727b202eb184c619c660a715438742af120bfa03440c51L1-R4) [[2]](diffhunk://#diff-e644090a9fdd02d5d3727b202eb184c619c660a715438742af120bfa03440c51R62-R73)

### Testing enhancements
* Added new tests in `test_homophones.py` for `get_homophones`, checking both the case where letter occurrences are greater than homophones and where they are fewer, ensuring correct length and usage. (`test/encipherment/test_homophones.py`, [test/encipherment/test_homophones.pyR89-R107](diffhunk://#diff-65e0f3ea762e26871a0b92db0c303d963cb16923060902c556d3b10dc7bb5f46R89-R107))
* Added a test in `test_cipher.py` to verify that all homophones are used in the ciphertext, matching the set of all possible homophones for the key. (`test/encipherment/test_cipher.py`, [test/encipherment/test_cipher.pyR35-R42](diffhunk://#diff-73ddfa1579b46b001abf7ffe4f9e34da9a505f9b82c8b6d497aca5bec5aa83a3R35-R42))

### Minor improvements
* Added necessary imports (`random`, `Counter`) to support new logic and testing. (`src/encipherment/cipher.py`, [[1]](diffhunk://#diff-e644090a9fdd02d5d3727b202eb184c619c660a715438742af120bfa03440c51L1-R4); `src/encipherment/homophones.py`, [[2]](diffhunk://#diff-88009526a85da0d7e1bdd364b9b8854087ea8ea2a6a84ddff97307c429140e4bR2); `test/encipherment/test_homophones.py`, [[3]](diffhunk://#diff-65e0f3ea762e26871a0b92db0c303d963cb16923060902c556d3b10dc7bb5f46R1)