### PR TITLE
Add tqdm progress bar to cipher generation loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "num2words>=0.5.14",
     "requests>=2.32.5",
+    "tqdm>=4.67.1",
     "unidecode>=1.4.0",
 ]
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+from tqdm import tqdm
 def generate_cipher(length: int | None, filename: str) -> None:
 	"""Generate a cipher from a random book slice and save it to a JSON file.
 	Args:
@@ -10,10 +11,7 @@ def generate_cipher(length: int | None, filename: str) -> None:
 	from utils.files import save_cipher
  
 	fetcher = Fetcher()
-	start_time = time.time()
 	book_text = fetcher.fetch_random_book_text()
-	book_fetch_time = time.time() - start_time
-	print(f"Fetched book text in {book_fetch_time:.2f} seconds.")
 	sliced_text = fetcher.get_random_book_slice(book_text, min_len=length if length else 500, max_len=length if length else 5000)
 	formatted_text = fetcher.format_text(sliced_text)
 
@@ -23,5 +21,5 @@ def generate_cipher(length: int | None, filename: str) -> None:
 
 
 if __name__ == "__main__": # pragma: no cover
-	for i in range(0, 10000):
+	for i in tqdm(range(10000)):
 		generate_cipher(5000, f"cipher-{i}.json")

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,6 @@ def generate_cipher(length: int | None, filename: str) -> None:
 	"""
 	from text_fetching.fetcher import Fetcher
 	from encipherment.cipher import Cipher
-	import time
 	from utils.files import save_cipher
  
 	fetcher = Fetcher()

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "num2words" },
     { name = "requests" },
+    { name = "tqdm" },
     { name = "unidecode" },
 ]
 
@@ -75,6 +76,7 @@ dev = [
 requires-dist = [
     { name = "num2words", specifier = ">=0.5.14" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "tqdm", specifier = ">=4.67.1" },
     { name = "unidecode", specifier = ">=1.4.0" },
 ]
 
@@ -313,6 +315,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/54/6177a0dc10bce6f43e392a2192e6018755473283d0cf43cc7e6afc182aea/ruff-0.13.1-py3-none-win32.whl", hash = "sha256:55e9efa692d7cb18580279f1fbb525146adc401f40735edf0aaeabd93099f9a0", size = 12178448, upload-time = "2025-09-18T19:52:35.545Z" },
     { url = "https://files.pythonhosted.org/packages/64/51/c6a3a33d9938007b8bdc8ca852ecc8d810a407fb513ab08e34af12dc7c24/ruff-0.13.1-py3-none-win_amd64.whl", hash = "sha256:3a3fb595287ee556de947183489f636b9f76a72f0fa9c028bdcabf5bab2cc5e5", size = 13286458, upload-time = "2025-09-18T19:52:38.198Z" },
     { url = "https://files.pythonhosted.org/packages/fd/04/afc078a12cf68592345b1e2d6ecdff837d286bac023d7a22c54c7a698c5b/ruff-0.13.1-py3-none-win_arm64.whl", hash = "sha256:c0bae9ffd92d54e03c2bf266f466da0a65e145f298ee5b5846ed435f6a00518a", size = 12437893, upload-time = "2025-09-18T19:52:41.283Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces the `tqdm` progress bar to improve the user experience when generating multiple ciphers, and removes unnecessary timing and print statements from the cipher generation process. The most important changes are:

**Dependency updates:**

* Added `tqdm` as a required dependency in `pyproject.toml` to support progress bars for long-running operations.

**Code improvements and user experience:**

* Imported `tqdm` in `src/main.py` and updated the main loop to wrap the range in `tqdm`, providing a progress bar when generating ciphers. [[1]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R1) [[2]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L26-R24)
* Removed timing and print statements related to fetching book text in `generate_cipher`, simplifying the function and reducing console clutter.