### PR TITLE
Input validation and error handling

### DIFF
--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -6,6 +6,9 @@ import re
 
 
 class Cipher:
+    
+    PLAINTEXT_PATTERN = re.compile(r"^[a-z]+$")
+    
     def __init__(self, plaintext: str, difficulty: int | None = None) -> None:
         """Initialize the Cipher object with the given plaintext.
 
@@ -13,8 +16,7 @@ class Cipher:
                 plaintext (str): The lowercase plaintext to be encrypted with no punctuation or spaces.
         """
 
-        pattern = re.compile(r"^[a-z]+$")
-        if not pattern.match(plaintext):
+        if not self.PLAINTEXT_PATTERN.match(plaintext):
             raise ValueError(
                 "Plaintext must contain only lowercase letters with no punctuation or spaces."
             )

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -6,102 +6,139 @@ import re
 
 
 class Cipher:
-    
-    PLAINTEXT_PATTERN = re.compile(r"^[a-z]+$")
-    
-    def __init__(self, plaintext: str, difficulty: int | None = None) -> None:
-        """Initialize the Cipher object with the given plaintext.
+	PLAINTEXT_PATTERN = re.compile(r"^[a-z]+$")
 
-        Args:
-                plaintext (str): The lowercase plaintext to be encrypted with no punctuation or spaces.
-        """
+	def __init__(self, plaintext: str, difficulty: int | None = None) -> None:
+		"""Initialize the Cipher object with the given plaintext.
 
-        if not self.PLAINTEXT_PATTERN.match(plaintext):
-            raise ValueError(
-                "Plaintext must contain only lowercase letters with no punctuation or spaces."
-            )
-        self.plaintext = plaintext
-        if not difficulty:
-            self.difficulty = self.generate_difficulty()
-        else: 
-            self.difficulty = difficulty
-        self.key = self.generate_key()
-        self.ciphertext = self.encipher()
+		Args:
+						plaintext (str): The lowercase plaintext to be encrypted with no punctuation or spaces.
+		"""
+  
+		self.plaintext = self._validate_plaintext(plaintext)
+		if not difficulty:
+			self.difficulty = self.generate_difficulty()
+		else:
+			self.difficulty = self._validate_difficulty(difficulty)
+		self.key = self.generate_key()
+		self.ciphertext = self.encipher()
 
-    def generate_key(self) -> dict:
-        """Generate a homophonic substitution cipher key based on the given difficulty level.
+	def _validate_plaintext(self, plaintext: str) -> str:
+		"""Validate the plaintext to ensure it contains only lowercase letters with no punctuation or spaces.
 
-        Key is a dictionary mapping each letter to a list of its homophones.
-        Each letter is assigned a number of homophones proportional to its frequency in English text,
-        with some random noise added to create variability.
+		Args:
+				plaintext (str): The plaintext to validate.
 
-        Each homophone is represented by a unique, randomly sampled number from 1 to the total number
-        of cipher symbols.
+		Returns:
+				str: The validated plaintext.
 
-        Returns:
-                dict: A dictionary mapping each letter to a list of its homophones.
-        """
-        cipher_symbols: int = round(len(self.plaintext) / self.difficulty)
-        
-        letter_frequencies = frequencies(self.plaintext)
+		Raises:
+				ValueError: If the plaintext contains invalid characters.
+		"""
+		if not isinstance(plaintext, str):
+			raise ValueError("Plaintext must be a string.")
+		if not plaintext:
+			raise ValueError("Plaintext must be a non-empty string.")
+		if not self.PLAINTEXT_PATTERN.match(plaintext):
+			raise ValueError(
+				"Plaintext must contain only lowercase letters with no punctuation or spaces."
+			)
+		return plaintext
+	
+	def _validate_difficulty(self, difficulty: int) -> int:
+		"""Validate the difficulty level to ensure it is between 4 and 20.
 
-        homophones_dict: dict[str, int] = extract_homophones(cipher_symbols, letter_frequencies)
+		Args:
+				difficulty (int): The difficulty level to validate.
 
-        homophone_numbers: list[int] = list(range(1, sum(homophones_dict.values()) + 1))
-        random.shuffle(homophone_numbers)
-        key: dict[str, list[int]] = {}
-        for letter, count in homophones_dict.items():
-            key[letter] = homophone_numbers[:count]
-            homophone_numbers = homophone_numbers[count:]
-        return key
+		Returns:
+				int: The validated difficulty level.
 
-    def encipher(self) -> str:
-        """Encipher the plaintext using the generated homophonic substitution cipher key.
+		Raises:
+				ValueError: If the difficulty level is not between 4 and 10.
+		"""
+		if not isinstance(difficulty, int):
+			raise ValueError("Difficulty must be an integer.")
+		if difficulty < 4 or difficulty > 20:
+			raise ValueError("Difficulty must be between 4 and 20.")
+		return difficulty
 
-        Returns:
-                str: The resulting ciphertext as a string of numbers separated by spaces.
-        """
-        counts = Counter(ch for ch in self.plaintext if ch in self.key)
+	def generate_key(self) -> dict:
+		"""Generate a homophonic substitution cipher key based on the given difficulty level.
 
-        homophones: dict[str, list[int]] = {}
-        ptr: dict[str, int] = {}
-        for letter, count in counts.items():
-            homophones[letter] = get_homophones(self.key[letter], count)
-            ptr[letter] = 0
+		Key is a dictionary mapping each letter to a list of its homophones.
+		Each letter is assigned a number of homophones proportional to its frequency in English text,
+		with some random noise added to create variability.
 
-        ciphertext_numbers: list[str] = []
-        for char in self.plaintext:
-            ciphertext_numbers.append(str(homophones[char][ptr[char]]))
-            ptr[char] += 1
-        return " ".join(ciphertext_numbers)
+		Each homophone is represented by a unique, randomly sampled number from 1 to the total number
+		of cipher symbols.
 
-    def generate_difficulty(self) -> int:
-        """Generate a difficulty level for the cipher based on the average occurences of each homophone.
-                Difficulty levels range from 4-10, with 4 being the most difficult.
+		Returns:
+						dict: A dictionary mapping each letter to a list of its homophones.
+		"""
+		cipher_symbols: int = round(len(self.plaintext) / self.difficulty)
 
-        Returns:
-                int: Difficulty level (4-10)
-        """
+		letter_frequencies = frequencies(self.plaintext)
 
-        return random.randint(4, 10)
+		homophones_dict: dict[str, int] = extract_homophones(
+			cipher_symbols, letter_frequencies
+		)
 
-    def __json__(self) -> dict:
-        """Return a JSON-serializable representation of the Cipher object.
+		homophone_numbers: list[int] = list(range(1, sum(homophones_dict.values()) + 1))
+		random.shuffle(homophone_numbers)
+		key: dict[str, list[int]] = {}
+		for letter, count in homophones_dict.items():
+			key[letter] = homophone_numbers[:count]
+			homophone_numbers = homophone_numbers[count:]
+		return key
 
-        Returns:
-                dict: A dictionary containing the plaintext, difficulty, key, and ciphertext.
-        """
-        return {
-            "plaintext": self.plaintext,
-            "difficulty": self.difficulty,
-            "key": self.key,
-            "ciphertext": self.ciphertext,
-        }
+	def encipher(self) -> str:
+		"""Encipher the plaintext using the generated homophonic substitution cipher key.
 
-    def __str__(self) -> str:
-        """Return a string representation of the Cipher object.
+		Returns:
+						str: The resulting ciphertext as a string of numbers separated by spaces.
+		"""
+		counts = Counter(ch for ch in self.plaintext if ch in self.key)
 
-        Returns:
-                str: A string containing the plaintext, difficulty, key, and ciphertext.
-        """
-        return f'Cipher(Plaintext: "{self.plaintext}"\nDifficulty: {self.difficulty}\nKey: {self.key}\nCiphertext: "{self.ciphertext}")'
+		homophones: dict[str, list[int]] = {}
+		ptr: dict[str, int] = {}
+		for letter, count in counts.items():
+			homophones[letter] = get_homophones(self.key[letter], count)
+			ptr[letter] = 0
+
+		ciphertext_numbers: list[str] = []
+		for char in self.plaintext:
+			ciphertext_numbers.append(str(homophones[char][ptr[char]]))
+			ptr[char] += 1
+		return " ".join(ciphertext_numbers)
+
+	def generate_difficulty(self) -> int:
+		"""Generate a difficulty level for the cipher based on the average occurences of each homophone.
+						Difficulty levels range from 4-10, with 4 being the most difficult.
+
+		Returns:
+						int: Difficulty level (4-10)
+		"""
+
+		return random.randint(4, 10)
+
+	def __json__(self) -> dict:
+		"""Return a JSON-serializable representation of the Cipher object.
+
+		Returns:
+						dict: A dictionary containing the plaintext, difficulty, key, and ciphertext.
+		"""
+		return {
+			"plaintext": self.plaintext,
+			"difficulty": self.difficulty,
+			"key": self.key,
+			"ciphertext": self.ciphertext,
+		}
+
+	def __str__(self) -> str:
+		"""Return a string representation of the Cipher object.
+
+		Returns:
+						str: A string containing the plaintext, difficulty, key, and ciphertext.
+		"""
+		return f'Cipher(Plaintext: "{self.plaintext}"\nDifficulty: {self.difficulty}\nKey: {self.key}\nCiphertext: "{self.ciphertext}")'

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -16,7 +16,7 @@ class Cipher:
 		"""
   
 		self.plaintext = self._validate_plaintext(plaintext)
-		if not difficulty:
+		if not difficulty and difficulty != 0:
 			self.difficulty = self.generate_difficulty()
 		else:
 			self.difficulty = self._validate_difficulty(difficulty)

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -2,6 +2,7 @@ from .homophones import extract_homophones, get_homophones
 from .frequency import frequencies
 import random
 from collections import Counter
+import re
 
 
 class Cipher:
@@ -11,7 +12,6 @@ class Cipher:
         Args:
                 plaintext (str): The lowercase plaintext to be encrypted with no punctuation or spaces.
         """
-        import re
 
         pattern = re.compile(r"^[a-z]+$")
         if not pattern.match(plaintext):
@@ -80,8 +80,6 @@ class Cipher:
         Returns:
                 int: Difficulty level (4-10)
         """
-
-        import random
 
         return random.randint(4, 10)
 

--- a/src/text_fetching/fetcher.py
+++ b/src/text_fetching/fetcher.py
@@ -157,14 +157,19 @@ class Fetcher:
 		Raises:
 			ValueError: If book_text is not a string or is shorter than min_len.
 		"""
-		if not book_text:
+		if not book_text or not isinstance(book_text, str):
 			raise ValueError(
-				"book_text must be a string"
+				"book_text must be a non-empty string"
 			)
-
-		if len(book_text) < min_len:
+   
+		if min_len < 1 or max_len < 1 or min_len > max_len:
 			raise ValueError(
-				"Length of book_text must be equal to or greater than min_len"
+				"min_len and max_len must be positive integers with min_len <= max_len"
+			)
+   
+		if len(book_text) < max_len:
+			raise ValueError(
+				"book_text is shorter than the specified max_len"
 			)
 		
 		book_text = self.format_text(book_text)

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -1,4 +1,6 @@
 from encipherment.cipher import Cipher
+import os
+import json
 
 def save_book(book_id: str, book_text: str) -> None:
 	"""Save the fetched book text to a local file for caching.
@@ -9,8 +11,7 @@ def save_book(book_id: str, book_text: str) -> None:
 	"""
 	if not book_text:
 		raise ValueError("book_text must be a non-empty string")
-
-	import os
+	
 	if not os.path.exists("books"):
 		os.makedirs("books")
 	with open(f"books/{book_id}.txt", "w", encoding="utf-8") as f:
@@ -25,7 +26,6 @@ def book_is_cached(book_id: str) -> bool:
 	Returns:
 		bool: True if the book file exists, False otherwise.
 	"""
-	import os
 	return os.path.exists(f"books/{book_id}.txt")
 
 def get_cached_book(book_id: str) -> str:
@@ -38,7 +38,6 @@ def get_cached_book(book_id: str) -> str:
 	Raises:
 		FileNotFoundError: If the book file does not exist.
 	"""
-	import os
 	if not os.path.exists(f"books/{book_id}.txt"):
 		raise FileNotFoundError(f"Book with ID {book_id} is not cached.")
 	with open(f"books/{book_id}.txt", "r", encoding="utf-8") as f:
@@ -52,8 +51,6 @@ def save_cipher(cipher_data: Cipher, filename: str) -> None:
 		cipher_data (dict): The cipher data to save.
 		filename (str): The name of the file to save the cipher.
 	"""
-	import json
-	import os
 	if not os.path.exists("ciphers"):
 		os.makedirs("ciphers")
 	with open(f"ciphers/{filename}", "w", encoding="utf-8") as f:

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -11,11 +11,17 @@ def save_book(book_id: str, book_text: str) -> None:
 	"""
 	if not book_text:
 		raise ValueError("book_text must be a non-empty string")
-	
-	if not os.path.exists("books"):
-		os.makedirs("books")
-	with open(f"books/{book_id}.txt", "w", encoding="utf-8") as f:
-		f.write(book_text)
+
+	try:
+		os.makedirs("books", exist_ok=True)
+	except OSError as e:
+		raise RuntimeError(f"Error creating books directory: {e}") from e
+
+	try:
+		with open(f"books/{book_id}.txt", "w", encoding="utf-8") as f:
+			f.write(book_text)
+	except (OSError, PermissionError) as e:
+		raise RuntimeError(f"Error saving book {book_id}: {e}") from e
 
 def book_is_cached(book_id: str) -> bool:
 	"""Check if a book with the given ID exists in the local cache.

--- a/src/utils/formatting.py
+++ b/src/utils/formatting.py
@@ -1,3 +1,5 @@
+import re
+
 def numbers_to_words(text: str) -> str:
 	"""Convert all numbers in the input text to their word representations.
  
@@ -8,7 +10,6 @@ def numbers_to_words(text: str) -> str:
 		str: The text with numbers converted to words.
 	"""
 	from num2words import num2words
-	import re
 	def replace_number(match):
 		"""Replace a number in the text with its word representation.
 

--- a/src/utils/formatting.py
+++ b/src/utils/formatting.py
@@ -1,4 +1,5 @@
 import re
+from num2words import num2words
 
 def numbers_to_words(text: str) -> str:
 	"""Convert all numbers in the input text to their word representations.
@@ -9,7 +10,6 @@ def numbers_to_words(text: str) -> str:
 	Returns:
 		str: The text with numbers converted to words.
 	"""
-	from num2words import num2words
 	def replace_number(match):
 		"""Replace a number in the text with its word representation.
 

--- a/test/encipherment/test_cipher.py
+++ b/test/encipherment/test_cipher.py
@@ -31,14 +31,17 @@ def test_legal_plaintext(sample_text_legal):
     assert all(isinstance(v, list) for v in cipher.key.values())
     assert isinstance(cipher.ciphertext, str)
     assert all(num.isdigit() for num in cipher.ciphertext.split())
-    
+
+
 def test_all_homophones_used(sample_text_legal):
-	cipher = Cipher(sample_text_legal)
-	used_homophones = set(int(num) for num in cipher.ciphertext.split())
-	all_homophones = set()
-	for homophones in cipher.key.values():
-		all_homophones.update(homophones)
-	assert used_homophones == all_homophones, f"Used homophones {used_homophones} do not match all homophones {all_homophones}"
+    cipher = Cipher(sample_text_legal)
+    used_homophones = set(int(num) for num in cipher.ciphertext.split())
+    all_homophones = set()
+    for homophones in cipher.key.values():
+        all_homophones.update(homophones)
+    assert used_homophones == all_homophones, (
+        f"Used homophones {used_homophones} do not match all homophones {all_homophones}"
+    )
 
 
 def test_illegal_plaintext(sample_texts_illegal):
@@ -49,22 +52,27 @@ def test_illegal_plaintext(sample_texts_illegal):
             "Plaintext must contain only lowercase letters with no punctuation or spaces."
             in str(excinfo.value)
         )
-        
+
+
 def test_defined_difficulty(sample_text_legal):
-	for difficulty in range(4, 11):
-		cipher = Cipher(sample_text_legal, difficulty=difficulty)
-		assert cipher.difficulty == difficulty
+    for difficulty in range(4, 11):
+        cipher = Cipher(sample_text_legal, difficulty=difficulty)
+        assert cipher.difficulty == difficulty
 
 
 def test_key_homophones_count(sample_text_legal):
     cipher = Cipher(sample_text_legal)
     total_homophones = sum(len(v) for v in cipher.key.values())
     expected_homophones = round(len(sample_text_legal) / cipher.difficulty)
-    
+
     # Assert that the total number of homophones is within a reasonable range of the expected value
-    assert abs(total_homophones - expected_homophones) <= 10, f"Total homophones {total_homophones} not within acceptable range of expected {expected_homophones}"
-    assert total_homophones >= expected_homophones, f"Total homophones {total_homophones} is less than expected {expected_homophones}"
-    
+    assert abs(total_homophones - expected_homophones) <= 10, (
+        f"Total homophones {total_homophones} not within acceptable range of expected {expected_homophones}"
+    )
+    assert total_homophones >= expected_homophones, (
+        f"Total homophones {total_homophones} is less than expected {expected_homophones}"
+    )
+
 
 def test_ciphertext_numbers_within_range(sample_text_legal):
     cipher = Cipher(sample_text_legal)
@@ -97,3 +105,46 @@ def test_str_representation(sample_text_legal):
     assert f"Difficulty: {cipher.difficulty}" in str_repr
     assert f"Key: {cipher.key}" in str_repr
     assert f'Ciphertext: "{cipher.ciphertext}"' in str_repr
+
+
+def test_invalid_difficulty(sample_text_legal):
+    for invalid_difficulty in [3, 21, -1, 0]:
+        with pytest.raises(ValueError) as excinfo:
+            Cipher(sample_text_legal, difficulty=invalid_difficulty)
+        assert "Difficulty must be between 4 and 20." in str(excinfo.value), (
+            f"Failed for difficulty {invalid_difficulty}"
+        )
+
+
+def test_non_integer_difficulty(sample_text_legal):
+    for non_integer in [5.5, "ten"]:
+        with pytest.raises(ValueError) as excinfo:
+            Cipher(sample_text_legal, difficulty=non_integer)
+        assert "Difficulty must be an integer." in str(excinfo.value)
+
+
+def test_non_string_plaintext():
+    for non_string in [12345, None, 5.67, ["list"], {"dict": "value"}]:
+        with pytest.raises(ValueError) as excinfo:
+            Cipher(non_string)
+        assert "Plaintext must be a string." in str(excinfo.value)
+
+
+def test_empty_string_plaintext():
+    with pytest.raises(ValueError) as excinfo:
+        Cipher("")
+    assert "Plaintext must be a non-empty string." in str(excinfo.value)
+
+
+def test_plaintext_with_non_english_letters():
+    for text in [
+        "thisisatestplaintextwithé",
+        "thisisatestplaintextwithñ",
+        "thisisatestplaintextwithü",
+    ]:
+        with pytest.raises(ValueError) as excinfo:
+            Cipher(text)
+        assert (
+            "Plaintext must contain only lowercase letters with no punctuation or spaces."
+            in str(excinfo.value)
+        )

--- a/test/text-fetching/test_fetcher.py
+++ b/test/text-fetching/test_fetcher.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 from text_fetching.fetcher import Fetcher
 
@@ -10,9 +11,11 @@ def sample_text_book():
 		Who said—“Two vast and trunkless legs of stone
 		Stand in the desert. . . ."""
 
+
 @pytest.fixture(autouse=True)
 def mock_save_book(mocker):
-	mocker.patch('text_fetching.fetcher.save_book')
+    mocker.patch("text_fetching.fetcher.save_book")
+
 
 @pytest.fixture
 def long_text():
@@ -28,9 +31,11 @@ def short_text():
 def no_text():
     return None
 
+
 @pytest.fixture
 def accented_text():
     return "kožušček François æåø äö êèéêñ"
+
 
 def test_format_text(sample_text_book):
     fetcher = Fetcher()
@@ -54,7 +59,7 @@ def test_format_notext(no_text):
 def test_format_regional_text(accented_text):
     fetcher = Fetcher()
     formatted_text = fetcher.format_text(accented_text)
-    assert(formatted_text == "kozuscekfrancoisaeaoaoeeeen")
+    assert formatted_text == "kozuscekfrancoisaeaoaoeeeen"
 
 
 def test_slicing_text(long_text):
@@ -70,7 +75,7 @@ def test_slicing_no_text(no_text):
     fetcher = Fetcher()
     with pytest.raises(ValueError) as excinfo:
         fetcher.get_random_book_slice(no_text)
-    assert "book_text must be a string" in str(excinfo.value)
+    assert "book_text must be a non-empty string" in str(excinfo.value)
 
 
 def test_slicing_short_text(short_text):
@@ -79,9 +84,7 @@ def test_slicing_short_text(short_text):
     assert len(short_text) < min_len
     with pytest.raises(ValueError) as excinfo:
         fetcher.get_random_book_slice(book_text=short_text, min_len=min_len)
-    assert "Length of book_text must be equal to or greater than min_len" in str(
-        excinfo.value
-    )
+    assert "book_text is shorter than the specified max_len" in str(excinfo.value)
 
 
 def test_fetch_book_success(mocker):
@@ -94,9 +97,7 @@ def test_fetch_book_success(mocker):
     }
 
     # Mock cached book check to return False
-    mocker.patch(
-		"text_fetching.fetcher.book_is_cached", return_value=False
-    )
+    mocker.patch("text_fetching.fetcher.book_is_cached", return_value=False)
 
     # Second response: actual book text
     mock_text_resp = mocker.Mock()
@@ -113,26 +114,25 @@ def test_fetch_book_success(mocker):
     assert isinstance(book_text, str)
     assert mock_get.call_count == 2
 
-def test_fetch_book_cached(mocker):
-	fetcher = Fetcher()
-	# Mock cached book check to return True
-	# Mock get_cached_book to return specific text
- 
-	mocker.patch(
-		"text_fetching.fetcher.book_is_cached", return_value=True)
-	mocker.patch(
-		"text_fetching.fetcher.get_cached_book", return_value="Cached book content."
-	)
 
-	# Mock requests.get to ensure it's not called
-	mock_get = mocker.patch(
-		"text_fetching.fetcher.requests.get"
-	)
-	book_text = fetcher.fetch_random_book_text()
-	assert book_text is not None
-	assert book_text == "Cached book content."
-	assert isinstance(book_text, str)
-	assert mock_get.call_count == 0  # Ensure no HTTP requests were made
+def test_fetch_book_cached(mocker):
+    fetcher = Fetcher()
+    # Mock cached book check to return True
+    # Mock get_cached_book to return specific text
+
+    mocker.patch("text_fetching.fetcher.book_is_cached", return_value=True)
+    mocker.patch(
+        "text_fetching.fetcher.get_cached_book", return_value="Cached book content."
+    )
+
+    # Mock requests.get to ensure it's not called
+    mock_get = mocker.patch("text_fetching.fetcher.requests.get")
+    book_text = fetcher.fetch_random_book_text()
+    assert book_text is not None
+    assert book_text == "Cached book content."
+    assert isinstance(book_text, str)
+    assert mock_get.call_count == 0  # Ensure no HTTP requests were made
+
 
 def test_fetch_book_no_format(mocker):
     mocker.patch("text_fetching.fetcher.book_is_cached", return_value=False)
@@ -157,6 +157,7 @@ def test_fetch_book_no_format(mocker):
 def test_fetch_book_request_exception(mocker):
     from requests import RequestException, Request, Response
 
+    mocker.patch("text_fetching.fetcher.book_is_cached", return_value=False)
     fetcher = Fetcher()
     # Mock requests.get to raise a RequestException
     mock_get = mocker.patch(
@@ -169,3 +170,71 @@ def test_fetch_book_request_exception(mocker):
         fetcher.fetch_random_book_text()
     assert "Error fetching book data: Network Error" in str(excinfo.value)
     assert mock_get.call_count == 1
+
+
+def test_fetch_book_invalid_id(mocker):
+    mocker.patch("text_fetching.fetcher.book_is_cached", return_value=False)
+    fetcher = Fetcher()
+    # Mock requests.get to raise a RequestException for invalid book ID
+    mock_get = mocker.patch(
+        "text_fetching.fetcher.requests.get",
+        side_effect=requests.RequestException("404 Client Error: Not Found for url"),
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        fetcher.fetch_random_book_text()
+    assert "Error fetching book data: 404 Client Error: Not Found for url" in str(
+        excinfo.value
+    )
+    assert mock_get.call_count == 1
+
+
+def test_fetch_book_empty_response(mocker):
+    fetcher = Fetcher()
+    # Mock the metadata response with empty formats
+    mock_metadata_resp = mocker.Mock()
+    mock_metadata_resp.raise_for_status.return_value = None
+    mock_metadata_resp.json.return_value = {"formats": {}}
+
+    mocker.patch("text_fetching.fetcher.book_is_cached", return_value=False)
+
+    mock_get = mocker.patch(
+        "text_fetching.fetcher.requests.get",
+        return_value=mock_metadata_resp,
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        fetcher.fetch_random_book_text()
+    assert "No suitable text format found" in str(excinfo.value)
+    assert mock_get.call_count == 1
+
+
+def test_book_slice_min_greater_than_max(long_text):
+    fetcher = Fetcher()
+    with pytest.raises(ValueError) as excinfo:
+        fetcher.get_random_book_slice(book_text=long_text, min_len=200, max_len=100)
+    assert (
+        "min_len and max_len must be positive integers with min_len <= max_len"
+        in str(excinfo.value)
+    )
+
+
+def test_book_slice_negative_lengths(long_text):
+    fetcher = Fetcher()
+    with pytest.raises(ValueError) as excinfo:
+        fetcher.get_random_book_slice(book_text=long_text, min_len=-50, max_len=100)
+    assert (
+        "min_len and max_len must be positive integers with min_len <= max_len"
+        in str(excinfo.value)
+    )
+    with pytest.raises(ValueError) as excinfo:
+        fetcher.get_random_book_slice(book_text=long_text, min_len=50, max_len=-100)
+    assert (
+        "min_len and max_len must be positive integers with min_len <= max_len"
+        in str(excinfo.value)
+    )
+
+
+def test_book_slice_length_smaller_than_max(long_text):
+    fetcher = Fetcher()
+    with pytest.raises(ValueError) as excinfo:
+        fetcher.get_random_book_slice(book_text=long_text, min_len=50, max_len=20000)
+    assert "book_text is shorter than the specified max_len" in str(excinfo.value)

--- a/test/utils/test_files.py
+++ b/test/utils/test_files.py
@@ -1,54 +1,97 @@
 import pytest
 from utils.files import save_book, book_is_cached, get_cached_book, save_cipher
 
+
 @pytest.fixture
 def sample_cipher():
-	from encipherment.cipher import Cipher
-	return Cipher("thisisatestcipher", 12)
+    from encipherment.cipher import Cipher
+
+    return Cipher("thisisatestcipher", 12)
+
 
 @pytest.fixture(autouse=True)
 def run_around_tests(tmp_path, monkeypatch):
-	monkeypatch.chdir(tmp_path) # Change to the temporary directory for the test
-	yield # Cleanup: Nothing needed as tmp_path is automatically cleaned up
+    monkeypatch.chdir(tmp_path)  # Change to the temporary directory for the test
+    yield  # Cleanup: Nothing needed as tmp_path is automatically cleaned up
+
 
 def test_save_book(tmp_path):
-	book_id = "test_book"
-	book_text = "This is a test book."
-	save_book(book_id, book_text)
-	saved_file = tmp_path / "books" / f"{book_id}.txt"
-	assert saved_file.exists()
-	assert saved_file.read_text() == book_text
- 
+    book_id = "test_book"
+    book_text = "This is a test book."
+    save_book(book_id, book_text)
+    saved_file = tmp_path / "books" / f"{book_id}.txt"
+    assert saved_file.exists()
+    assert saved_file.read_text() == book_text
+
+
 def test_save_book_empty_text():
-	book_id = "empty_book"
-	book_text = ""
-	with pytest.raises(ValueError):
-		save_book(book_id, book_text)
-  
+    book_id = "empty_book"
+    book_text = ""
+    with pytest.raises(ValueError):
+        save_book(book_id, book_text)
+
+
 def test_book_is_cached(tmp_path):
-	book_id = "cached_book"
-	book_text = "This book is cached."
-	assert not book_is_cached(book_id)
-	save_book(book_id, book_text)
-	assert book_is_cached(book_id)
- 
+    book_id = "cached_book"
+    book_text = "This book is cached."
+    assert not book_is_cached(book_id)
+    save_book(book_id, book_text)
+    assert book_is_cached(book_id)
+
+
 def test_get_cached_book(tmp_path):
-	book_id = "cached_book"
-	book_text = "This book is cached."
-	save_book(book_id, book_text)
-	retrieved_text = get_cached_book(book_id)
-	assert retrieved_text == book_text
- 
+    book_id = "cached_book"
+    book_text = "This book is cached."
+    save_book(book_id, book_text)
+    retrieved_text = get_cached_book(book_id)
+    assert retrieved_text == book_text
+
+
 def test_get_cached_book_not_found():
-	book_id = "nonexistent_book"
-	with pytest.raises(FileNotFoundError):
-		get_cached_book(book_id)
-  
+    book_id = "nonexistent_book"
+    with pytest.raises(FileNotFoundError):
+        get_cached_book(book_id)
+
+
 def test_save_cipher(tmp_path, sample_cipher):
-	filename = "test_cipher.json"
-	save_cipher(sample_cipher, filename)
-	saved_file = tmp_path / "ciphers" / filename
-	assert saved_file.exists()
-	import json
-	saved_content = json.loads(saved_file.read_text())
-	assert saved_content == sample_cipher.__json__()
+    filename = "test_cipher.json"
+    save_cipher(sample_cipher, filename)
+    saved_file = tmp_path / "ciphers" / filename
+    assert saved_file.exists()
+    import json
+
+    saved_content = json.loads(saved_file.read_text())
+    assert saved_content == sample_cipher.__json__()
+
+
+def test_save_cipher_no_ciphers_dir(tmp_path, sample_cipher):
+    filename = "test_cipher.json"
+    # Ensure ciphers directory does not exist
+    ciphers_dir = tmp_path / "ciphers"
+    if ciphers_dir.exists():
+        for file in ciphers_dir.iterdir():
+            file.unlink()
+        ciphers_dir.rmdir()
+    save_cipher(sample_cipher, filename)
+    saved_file = tmp_path / "ciphers" / filename
+    assert saved_file.exists()
+
+
+def test_save_book_error_creating_dir(monkeypatch, sample_cipher):
+    def mock_makedirs_fail(path, exist_ok=False):
+        raise OSError("Mocked error creating directory")
+
+    monkeypatch.setattr("os.makedirs", mock_makedirs_fail)
+    with pytest.raises(RuntimeError) as excinfo:
+        save_book("book_id", "Some book text")
+    assert "Error creating books directory" in str(excinfo.value)
+
+
+def test_save_book_error_writing_file(monkeypatch, tmp_path):
+    def mock_open_fail(*args, **kwargs):
+        raise OSError("Mocked error opening file")
+
+    monkeypatch.setattr("builtins.open", mock_open_fail)
+    with pytest.raises(RuntimeError) as excinfo:
+        save_book("book_id", "Some book text")
+    assert "Error saving book" in str(excinfo.value)


### PR DESCRIPTION
This pull request introduces several improvements to input validation and error handling across the codebase, especially in the cipher and file utility modules. The main changes include refactoring validation logic for plaintext and difficulty in the `Cipher` class, strengthening error handling when saving files, and improving input checks in text fetching utilities.

### Input validation and error handling improvements

* Refactored plaintext and difficulty validation in the `Cipher` class (`src/encipherment/cipher.py`): Added `_validate_plaintext` and `_validate_difficulty` methods to enforce stricter type and value checks, replacing inline validation logic. This improves code readability and reliability.
* Enhanced error handling in `save_book` (`src/utils/files.py`): Directory creation and file writing now use `try/except` blocks to raise descriptive `RuntimeError` exceptions on failure, making file operations more robust.
* Improved input validation in `get_random_book_slice` (`src/text_fetching/fetcher.py`): Added checks for type and length of `book_text`, and for the validity of `min_len` and `max_len` parameters, raising appropriate errors for invalid inputs.

### Code cleanup and consistency

* Removed redundant imports and standardized import placement in utility modules (`src/utils/files.py`, `src/utils/formatting.py`): Consolidated imports at the top of files and eliminated unnecessary repeated imports from within functions. [[1]](diffhunk://#diff-ef0a9d67c41e1cf922e7bf076c1362c83e853b3759717eafcd51ae66c0882441R2-R3) [[2]](diffhunk://#diff-d659cb7430704b17fc3f11ef0fc89ca4747027b7e94617463a7ffd03c3795ea4R1-R2) [[3]](diffhunk://#diff-d659cb7430704b17fc3f11ef0fc89ca4747027b7e94617463a7ffd03c3795ea4L11)
* Minor formatting and consistency improvements in `generate_key` and related methods in the `Cipher` class, aligning code style and parameter usage. [[1]](diffhunk://#diff-e644090a9fdd02d5d3727b202eb184c619c660a715438742af120bfa03440c51L46-R85) [[2]](diffhunk://#diff-e644090a9fdd02d5d3727b202eb184c619c660a715438742af120bfa03440c51L84-L85)